### PR TITLE
'compile' is obsolete

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,7 +40,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile "com.android.support:cardview-v7:${safeExtGet('supportLibVersion','26.1.0')}"
+    implementation 'com.facebook.react:react-native:+'
+    implementation "com.android.support:cardview-v7:${safeExtGet('supportLibVersion','26.1.0')}"
 }
   


### PR DESCRIPTION
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.

<img width="959" alt="Screenshot 2020-08-06 at 13 44 16" src="https://user-images.githubusercontent.com/4986411/89528207-f3279c80-d7ea-11ea-8500-122bf613185c.png">
